### PR TITLE
Add repositories dependent on sufia, curation_concerns, hydra-head, rubydora

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -158,5 +158,9 @@
         "base": "sufia",
         "source": "dependency graph",
         "url": "https://github.com/psu-stewardship/scholarsphere"
+    {
+        "base": "curation_concerns",
+        "source": "dependency graph",
+        "url": "https://github.com/ucsblibrary/alexandria"
     }
 ]

--- a/repositories.json
+++ b/repositories.json
@@ -82,11 +82,6 @@
     {
         "base": "hyrax",
         "source": "dependency graph",
-        "url": "https://github.com/marriott-library/newspaper_works"
-    },
-    {
-        "base": "hyrax",
-        "source": "dependency graph",
         "url": "https://github.com/research-technologies/hyrax_leaf"
     },
     {

--- a/repositories.json
+++ b/repositories.json
@@ -143,5 +143,20 @@
         "base": "valkyrie",
         "source": "dependency graph",
         "url": "https://github.com/psu-libraries/cho"
+    },
+    {
+        "base": "sufia",
+        "source": "dependency graph",
+        "url": "https://github.com/sciencehistory/chf-sufia"
+    },
+    {
+        "base": "sufia",
+        "source": "dependency graph",
+        "url": "https://github.com/galterlibrary/digital-repository"
+    },
+    {
+        "base": "sufia",
+        "source": "dependency graph",
+        "url": "https://github.com/psu-stewardship/scholarsphere"
     }
 ]

--- a/repositories.json
+++ b/repositories.json
@@ -30,12 +30,12 @@
         "url": "https://github.com/osulp/Scholars-Archive"
     },
     {
-        "base": "hydra",
+        "base": "hydra-head",
         "source": "wiki",
         "url": "https://github.com/OregonDigital/oregondigital/"
     },
     {
-        "base": "hydra",
+        "base": "hydra-head",
         "source": "wiki",
         "url": "https://github.com/duke-libraries/ddr-public"
     },
@@ -153,9 +153,35 @@
         "base": "sufia",
         "source": "dependency graph",
         "url": "https://github.com/psu-stewardship/scholarsphere"
+    },
     {
         "base": "curation_concerns",
         "source": "dependency graph",
         "url": "https://github.com/ucsblibrary/alexandria"
+    },
+    {
+        "base": "hydra-head",
+        "source": "dependency graph",
+        "url": "https://github.com/digital-york/arch1"
+    },
+    {
+        "base": "hydra-head",
+        "source": "dependency graph",
+        "url": "https://github.com/ucsdlib/damspas"
+    },
+    {
+        "base": "hydra-head",
+        "source": "dependency graph",
+        "url": "https://github.com/ndlib/curate_nd"
+    },
+    {
+        "base": "rubydora",
+        "source": "dependency graph",
+        "url": "https://github.com/cul/ldpd-hyacinth"
+    },
+    {
+        "base": "rubydora",
+        "source": "dependency graph",
+        "url": "https://github.com/sul-dlss/hydrus"
     }
 ]


### PR DESCRIPTION
I also checked hydra and there was nothing to see there.

I considered looking at active fedora, but it had nearly 700 dependents and most of what we found would already be in the file from looking at the other projects.